### PR TITLE
Fix support for dhcp_template

### DIFF
--- a/manifests/dhcp.pp
+++ b/manifests/dhcp.pp
@@ -6,7 +6,7 @@
 class cobbler::dhcp (
   $package         = undef,
   $service         = undef,
-  $tmpl_dhcp_conf  = 'cobbler/dhcp.template.erb',
+  $dhcp_template   = undef,
   $nameservers     = undef,
   $interfaces      = undef,
   $subnets         = undef,
@@ -32,7 +32,7 @@ class cobbler::dhcp (
     group   => root,
     mode    => '0644',
     require => Package['cobbler'],
-    content => template($tmpl_dhcp_conf),
+    content => template($dhcp_template),
     notify  => Exec['cobblersync'],
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,6 +17,7 @@ class cobbler (
   $dhcp_option             = 'isc',
   $dhcp_package            = $::cobbler::params::dhcp_package,
   $dhcp_service            = $::cobbler::params::dhcp_service,
+  $dhcp_template           = 'cobbler/dhcp.template.erb',
   $dhcp_interfaces         = [ 'eth0' ],
   $dhcp_subnets            = [],
   $dhcp_nameservers        = [ '8.8.8.8', '8.8.4.4' ],
@@ -150,12 +151,13 @@ class cobbler (
   # include ISC DHCP only if we choose manage_dhcp
   if ( $manage_dhcp == '1' ) and ( $dhcp_option == 'isc' ) {
     class { '::cobbler::dhcp':
-      package       => $dhcp_package,
-      service       => $dhcp_service,
-      nameservers   => $dhcp_nameservers,
-      interfaces    => $dhcp_interfaces,
-      subnets       => $dhcp_subnets,
-      dynamic_range => $dhcp_dynamic_range,
+      package        => $dhcp_package,
+      service        => $dhcp_service,
+      dhcp_template  => $dhcp_template,
+      nameservers    => $dhcp_nameservers,
+      interfaces     => $dhcp_interfaces,
+      subnets        => $dhcp_subnets,
+      dynamic_range  => $dhcp_dynamic_range,
     }
   }
 


### PR DESCRIPTION
Class cobbler::dhcp was not designed to be called directly, so
custom template has to be forwarded from main class